### PR TITLE
Update geo/core/functions to correct url

### DIFF
--- a/geo/core/functions
+++ b/geo/core/functions
@@ -10,12 +10,13 @@ get_current_location() {
 
 		local query=$(echo $wifi_points | tr -d '}"\\' | \
 			awk 'BEGIN {RS=","; FS=":"}
-			/mac_address/ { gsub(/ /,"", $2); printf "wifi=mac:%s",$2 }
+			/mac_address/ { gsub(/ /,"", $2); printf "&wifi=mac:%s",$2 }
+			/ssid/ { gsub(/^ */,"", $2); gsub(/ /,"%20",$2); printf "|ssid:%s",$2 }
 			/signal_strength/ { gsub(/ /,"", $2); printf "|ss:%s",$2 }
-			/ssid/ { gsub(/^ */,"", $2); gsub(/ /,"%20",$2); printf "|ssid:%s&",$2 }')
+			')
 
 		local url="https://maps.googleapis.com/maps/api/browserlocation/json"
-		local full_req="${url}?browser=true&sensor=true&${query}"
+		local full_req="${url}?browser=true&sensor=true${query}"
 
 		current_location_json="$(getter ${full_req})"
 	fi


### PR DESCRIPTION
Many users have been complaining about locations that are within a few miles of correct, but not correct.  I noticed that the URLs seem to be improperly formed with prey 0.5.9.

Sample of 0.5.9 URL:
https://maps.googleapis.com/maps/api/browserlocation/json?browser=true&sensor=true&wifi=mac:(MAC ADDRESS)|ssid:(SSID)&|ss:-56wifi=mac:(MAC ADDRESS)|ssid:(SSID)&|ss:-81

Notice the locations of the "&" characters, I don't think they are in the correct location.  If I give a URL formatted like the one above  to Google, an inaccurate location is returned.  However, my location is properly returned if the URL is formatted as below, with & characters between each WiFi Hotspot that was found.

https://maps.googleapis.com/maps/api/browserlocation/json?browser=true&sensor=true&wifi=mac:(MAC ADDRESS)|ssid:(SSID)|ss:-56&wifi=mac:(MAC ADDRESS)|ssid:(SSID)|ss:-81

This commit changes the insertion point of the & character to be just before the string "wifi" instead of having it between the SSID and Signal Strength.

As a side note, I think these JSON URLs are limited to 2048 characters, and Prey does not seem to have a check for this.  I'm not sure if this is a problem or not.  I did not address this.
