### PR TITLE
Fix use of python instead of python2 on linux.

### DIFF
--- a/lock/platform/linux/prey-lock
+++ b/lock/platform/linux/prey-lock
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #############################################
 # Prey Linux Lock
 # By Tomas Pollak - (c) 2010 Fork Ltd.

--- a/retrieve/core/functions
+++ b/retrieve/core/functions
@@ -206,7 +206,7 @@ get_last_bucket_in_s3(){
 
 upload_to_ubuntu_one(){
 
-	[ -z "$(which python)" ] && log " -- Python interpreter not found! Cannot continue." && return 1
+	[ -z "$(which python2)" ] && log " -- Python interpreter not found! Cannot continue." && return 1
 
 	local file_to_upload="$1"
 	local credentials_file='credentialfile.txt'
@@ -236,7 +236,7 @@ upload_to_ubuntu_one(){
 
 	fi
 
-	python "${module_path}/lib/u1_upload.py" "$file_to_upload"
+	python2 "${module_path}/lib/u1_upload.py" "$file_to_upload"
 	rs=$?
 
 	rm -f "$credentials_file"

--- a/retrieve/lib/u1_upload.py
+++ b/retrieve/lib/u1_upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #############################################
 # Prey Ubuntu One API
 # By Tomas Pollak - (c) 2011 Fork Ltd.

--- a/retrieve/lib/u1rest/createfilekeystore.py
+++ b/retrieve/lib/u1rest/createfilekeystore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #Copyright (C) 2011 by John O'Brien
 #
 #Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Due to Arch Linux's use of Python 3 as default, the /usr/bin/python symlink causes some things to fail. I've fixed it so that the python2 symlink is used, invoked through env instead of directly using the symlink, just in case some distro moves it. As far as I know, env is in a fixed position on every distro.
