### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 These modules provide the core functionality for the Prey Bash client.
 They are run when triggered remotely, either the official Control Panel
-(panel.preyproject.com) or through the [Standalone Panel](/prey/prey-standalone-control-panel).
+(panel.preyproject.com) or through the [Standalone Panel](https://github.com/prey/prey-standalone-control-panel).
 
 # How they work
 


### PR DESCRIPTION
Only files in the same repo can be relative. Bit of an oversight on GH's part.

See the [blog post](https://github.com/blog/1395-relative-links-in-markup-files)