### PR TITLE
Don't submit more than 25 WiFi networks when calling the Google Maps API...

### DIFF
--- a/geo/core/functions
+++ b/geo/core/functions
@@ -19,6 +19,9 @@ get_current_location() {
 		local full_req="${url}?browser=true&sensor=true${query}"
 
 		current_location_json="$(getter ${full_req})"
+		if echo "$current_location_json" | grep -qi '<title>error'; then
+			current_location_json=""
+		fi
 	fi
 }
 

--- a/geo/platform/mac/functions
+++ b/geo/platform/mac/functions
@@ -11,7 +11,7 @@ get_wifi_access_points() {
 	if [ -n "$wifi_info" ]; then
 
 		wifi_points=`$airport -s -x | egrep 'BSSID|>CHANNEL<|NOISE|SSID_STR|RSSI' --after-context=1 \
-		| egrep -v "AGE|array|WPA|80211" | tr '\n' ' ' | tr -d '\t' \
+		| head -374 | egrep -v "AGE|array|WPA|80211" | tr '\n' ' ' | tr -d '\t' \
 		| sed -e 's/<[^>]*>//g' \
 		-e 's/ -- /, /g' \
 		-e 'y/:/-/' \


### PR DESCRIPTION
When there are too many WiFi networks the constructed Google Maps API
request becomes too large, and Google returns an error. This patch
limits the request to 25 networks, and also adds error handling so the
report is still sent even if Google returns an error.

This fixes prey-bash-client issues #395 and #396.
