### PR TITLE
Fixed Linux systems requiring to be logged in to take a screenshot

### DIFF
--- a/session/platform/linux/functions
+++ b/session/platform/linux/functions
@@ -7,10 +7,15 @@
 
 get_screenshot() {
 
+	local xwd=`which xwd` # standard xorg tool
 	local scrot=`which scrot` # scrot is lighter
 	local import=`which import` # imagemagick
 
-	if [ -n "$scrot" ]; then
+	if [ -n "$xwd" ]; then
+ 
+		/usr/bin/xwd -display :0 -root | convert - $session__screenshot 
+
+	elif [ -n "$scrot" ]; then
 
 		run_as_current_user "$scrot $session__screenshot"
 


### PR DESCRIPTION
We include this fix in @openSUSE for 5 years now. It seems the patch at https://groups.google.com/forum/#!topic/prey-security/HYlLDYDtOaU was never recognized.